### PR TITLE
Make Mafile DKMS compatible

### DIFF
--- a/driver/Makefile
+++ b/driver/Makefile
@@ -7,7 +7,8 @@ obj-m := MergingRavennaALSA.o
 MergingRavennaALSA-objs := c_wrapper_lib.o audio_driver.o manager.o module_main.o PTP.o module_interface.o module_netlink.o module_timer.o EtherTubeNetfilter.o RTP_streams_manager.o RTP_audio_stream.o RTP_stream.o RTP_stream_info.o MTAL_EthUtils.o MTAL_LKernelAPI.o MTConvert.o
 
 MAKE = make
-KSRC = /lib/modules/$(shell uname -r)/build/
+KERNELRELEASE = $(shell uname -r)
+KSRC = /lib/modules/$(KERNELRELEASE)/build/
 SRC = $(shell pwd)
 
 modules:


### PR DESCRIPTION
DKMS passes the desired kernel version via the `KERNELRELEASE` variable into the makefile. This patch allows dkms to pass the kernel version, while maintaining the original behavior.