### PR TITLE
Aes67 daemon issue11

### DIFF
--- a/driver/MTAL_EthUtils.c
+++ b/driver/MTAL_EthUtils.c
@@ -104,14 +104,13 @@ void MTAL_DumpID(uint64_t ullID)
 	uint32_t ui32;
 	for(ui32 = 0; ui32 < sizeof(ullID); ui32++)
 	{
-		uint8_t by = (ullID >> (ui32 * 8)) & 0xFF;
 		if(ui32 > 0)
 		{
-			MTAL_DP(":%2.2X", by);
+			MTAL_DP(":%2.2X", (ullID >> (ui32 * 8)) & 0xFF);
 		}
 		else
 		{
-			MTAL_DP("%2.2X", by);
+			MTAL_DP("%2.2X", (ullID >> (ui32 * 8)) & 0xFF);
 		}
 	}
 	MTAL_DP("\n");
@@ -553,8 +552,7 @@ void MTAL_DumpAppleMIDI(TAppleMIDI_PacketBase* pAppleMIDI_PacketBase)
 			break;
 		case APPLEMIDI_COMMAND_SYNCHRONIZATION:
 		{
-			TAppleMIDI_Synch_Packet* pSynch = (TAppleMIDI_Synch_Packet*)pAppleMIDI_PacketBase;
-			MTAL_DP("Synchronization[%d]", pSynch->ui8Count);
+			MTAL_DP("Synchronization[%d]", ((TAppleMIDI_Synch_Packet*)pAppleMIDI_PacketBase)->ui8Count);
 			break;
 		}
 		case APPLEMIDI_COMMAND_RECEIVER_FEEDBACK:
@@ -577,10 +575,9 @@ void MTAL_DumpAppleMIDI(TAppleMIDI_PacketBase* pAppleMIDI_PacketBase)
 		case APPLEMIDI_COMMAND_INVITATION_ACCEPTED:
 		case APPLEMIDI_COMMAND_ENDSESSION:
 		{
-			TAppleMIDI_IN_NO_OK_BY_Packet* pAppleMIDI_IN_NO_OK_BY_Packet = (TAppleMIDI_IN_NO_OK_BY_Packet*)pAppleMIDI_PacketBase;
-			MTAL_DP("\tProtocol Version = %d\n", MTAL_SWAP32(pAppleMIDI_IN_NO_OK_BY_Packet->ui32ProtocolVersion));
-			MTAL_DP("\tInitiator token = 0x%x\n", MTAL_SWAP32(pAppleMIDI_IN_NO_OK_BY_Packet->ui32InitiatorToken));
-			MTAL_DP("\tSender SSRC = 0x%x\n", MTAL_SWAP32(pAppleMIDI_IN_NO_OK_BY_Packet->ui32SenderSSRC));
+			MTAL_DP("\tProtocol Version = %d\n", MTAL_SWAP32((TAppleMIDI_IN_NO_OK_BY_Packet*)pAppleMIDI_PacketBase->ui32ProtocolVersion));
+			MTAL_DP("\tInitiator token = 0x%x\n", MTAL_SWAP32((TAppleMIDI_IN_NO_OK_BY_Packet*)pAppleMIDI_PacketBase->ui32InitiatorToken));
+			MTAL_DP("\tSender SSRC = 0x%x\n", MTAL_SWAP32((TAppleMIDI_IN_NO_OK_BY_Packet*)pAppleMIDI_PacketBase->ui32SenderSSRC));
 			break;
 		}
 	}

--- a/driver/MTConvert.c
+++ b/driver/MTConvert.c
@@ -173,7 +173,7 @@ static uint32_t GetFeatures()
     #include <asm/uaccess.h>
 #endif
 
-void MTConvertInit() //Init_Converter()
+void MTConvertInit(void) //Init_Converter()
 {
     if(g_bInitialized)
     {

--- a/driver/RTP_audio_stream.c
+++ b/driver/RTP_audio_stream.c
@@ -1041,11 +1041,10 @@ void PrepareBufferLives(TRTP_audio_stream* self)
 			if(self->m_ulLivesInDMCounter < pManager->get_live_in_jitter_buffer_length(pManager->user) / pManager->get_frame_size(pManager->user))
 			{
 				unsigned short us;
-				int64_t delta = self->m_tRTPStream.m_ui64LastAudioSampleReceivedSAC - pManager->get_global_SAC(pManager->user);
 				#ifndef WIN32
-					MTAL_DP("sink %s: is muted at globalSAC = %llu (delta = %lld)\n", pRTP_stream_info->m_cName, pManager->get_global_SAC(pManager->user), delta);
+					MTAL_DP("sink %s: is muted at globalSAC = %llu (delta = %lld)\n", pRTP_stream_info->m_cName, pManager->get_global_SAC(pManager->user), self->m_tRTPStream.m_ui64LastAudioSampleReceivedSAC - pManager->get_global_SAC(pManager->user));
 				#else
-					MTAL_DP("sink %s: is muted at globalSAC = %I64u (delta = %I64)\n", pRTP_stream_info->m_cName, pManager->get_global_SAC(pManager->user), delta);
+					MTAL_DP("sink %s: is muted at globalSAC = %I64u (delta = %I64)\n", pRTP_stream_info->m_cName, pManager->get_global_SAC(pManager->user), self->m_tRTPStream.m_ui64LastAudioSampleReceivedSAC - pManager->get_global_SAC(pManager->user));
 				#endif
 				self->m_ulLivesInDMCounter++;
 

--- a/driver/audio_driver.c
+++ b/driver/audio_driver.c
@@ -1301,7 +1301,7 @@ static int mr_alsa_audio_pcm_hw_params( struct snd_pcm_substream *substream,
     struct mr_alsa_audio_chip *chip = snd_pcm_substream_chip(substream);
     //struct snd_pcm_runtime *runtime = substream->runtime;
     //unsigned long flags;
-    uint32_t ptp_frame_size;
+    uint32_t ptp_frame_size = 0;
     unsigned int        rate = params_rate(params);
     snd_pcm_format_t    format = params_format(params);
     unsigned int nbCh = params_channels(params);

--- a/driver/audio_driver.c
+++ b/driver/audio_driver.c
@@ -65,11 +65,11 @@
 
 
 /// reminder:
-//#define SNDRV_PCM_FORMAT_DSD_U8         ((__force snd_pcm_format_t) 48) /* DSD, 1-byte samples DSD (x8) */
-//#define SNDRV_PCM_FORMAT_DSD_U16_LE     ((__force snd_pcm_format_t) 49) /* DSD, 2-byte samples DSD (x16), little endian */
-//#define SNDRV_PCM_FORMAT_DSD_U32_LE     ((__force snd_pcm_format_t) 50) /* DSD, 4-byte samples DSD (x32), little endian */
-//#define SNDRV_PCM_FORMAT_DSD_U16_BE     ((__force snd_pcm_format_t) 51) /* DSD, 2-byte samples DSD (x16), big endian */
-//#define SNDRV_PCM_FORMAT_DSD_U32_BE     ((__force snd_pcm_format_t) 52) /* DSD, 4-byte samples DSD (x32), big endian */
+//#define SNDRV_PCM_FORMAT_DSD_U8         ((__force snd_pcm_format_t) 48) /* DSD, 1-byte samples DSD (x8)
+//#define SNDRV_PCM_FORMAT_DSD_U16_LE     ((__force snd_pcm_format_t) 49) /* DSD, 2-byte samples DSD (x16), little endian
+//#define SNDRV_PCM_FORMAT_DSD_U32_LE     ((__force snd_pcm_format_t) 50) /* DSD, 4-byte samples DSD (x32), little endian
+//#define SNDRV_PCM_FORMAT_DSD_U16_BE     ((__force snd_pcm_format_t) 51) /* DSD, 2-byte samples DSD (x16), big endian
+//#define SNDRV_PCM_FORMAT_DSD_U32_BE     ((__force snd_pcm_format_t) 52) /* DSD, 4-byte samples DSD (x32), big endian
 
 
 static int index = SNDRV_DEFAULT_IDX1; /* Index 0-max */
@@ -604,11 +604,11 @@ static int mr_alsa_audio_pcm_interrupt(void *rawchip, int direction)
             unsigned long bytes_to_frame_factor;
             struct snd_pcm_runtime *runtime = chip->capture_substream->runtime;
             ring_buffer_size = chip->current_dsd ? MR_ALSA_RINGBUFFER_NB_FRAMES : runtime->period_size * runtime->periods;
-            if (ring_buffer_size > MR_ALSA_RINGBUFFER_NB_FRAMES)
+            /*if (ring_buffer_size > MR_ALSA_RINGBUFFER_NB_FRAMES)
             {
                 printk(KERN_ERR "mr_alsa_audio_pcm_interrupt capture period_size*periods > MR_ALSA_RINGBUFFER_NB_FRAMES\n");
                 return -2;
-            }
+            }*/
             
             /// DMA case
             bytes_to_frame_factor = runtime->channels * chip->current_alsa_capture_stride;
@@ -641,11 +641,11 @@ static int mr_alsa_audio_pcm_interrupt(void *rawchip, int direction)
             unsigned long bytes_to_frame_factor;
             struct snd_pcm_runtime *runtime = chip->playback_substream->runtime;
             ring_buffer_size = chip->current_dsd ? MR_ALSA_RINGBUFFER_NB_FRAMES : runtime->period_size * runtime->periods;
-            if (ring_buffer_size > MR_ALSA_RINGBUFFER_NB_FRAMES)
+            /*if (ring_buffer_size > MR_ALSA_RINGBUFFER_NB_FRAMES)
             {
                 printk(KERN_ERR "mr_alsa_audio_pcm_interrupt playback period_size*periods > MR_ALSA_RINGBUFFER_NB_FRAMES\n");
                 return -2;
-            }
+            }*/
 
             bytes_to_frame_factor = runtime->channels * chip->current_alsa_playback_stride;
             //printk(KERN_DEBUG "playback copy pos=%u, dma_pos=%u, count=%u, channels=%d pcm_size=%u\n", chip->playback_buffer_pos, pos, ptp_frame_size, runtime->channels, pcm_buffer_size);
@@ -1665,17 +1665,20 @@ static int mr_alsa_audio_pcm_open(struct snd_pcm_substream *substream)
                 t.max = bits;
         }
 
-        //printk("mr_alsa_audio_pcm_open: playback format nb bits range:  [%u, %u]\n", t.min, t.max);
+        printk("mr_alsa_audio_pcm_open: playback format nb bits range: [%u, %u]\n", t.min, t.max);
 
         period_bytes_min = minPTPFrameSize * mr_alsa_audio_pcm_hardware_playback.channels_min * (t.min >> 3); // amount of data in bytes for min channels, smallest sample size in bytes, minimum period size
         period_bytes_max = maxPTPFrameSize * mr_alsa_audio_pcm_hardware_playback.channels_max * (t.max >> 3); // amount of data in bytes for max channels, largest sample size in bytes, maximum period size
         periods_min = 2;
-        periods_max = MR_ALSA_RINGBUFFER_NB_FRAMES / minPTPFrameSize;
+        periods_max = MR_ALSA_RINGBUFFER_NB_FRAMES / maxPTPFrameSize;
 
         mr_alsa_audio_pcm_hardware_playback.period_bytes_min = period_bytes_min;
         mr_alsa_audio_pcm_hardware_playback.period_bytes_max = period_bytes_max;
         mr_alsa_audio_pcm_hardware_playback.periods_min = periods_min;
         mr_alsa_audio_pcm_hardware_playback.periods_max = periods_max;
+
+        printk("mr_alsa_audio_pcm_open: playback period size range: [%zu, %zu], periods range: [%u, %u]\n",
+              period_bytes_min, period_bytes_max, periods_min, periods_max);
 
         runtime->hw = mr_alsa_audio_pcm_hardware_playback;
 
@@ -1728,12 +1731,15 @@ static int mr_alsa_audio_pcm_open(struct snd_pcm_substream *substream)
             if (t.max < (unsigned)bits)
                 t.max = bits;
         }
-        //printk("mr_alsa_audio_pcm_open: capture format nb bits range:  [%u, %u]\n", t.min, t.max);
+        printk("mr_alsa_audio_pcm_open: capture format nb bits range: [%u, %u]\n", t.min, t.max);
 
         period_bytes_min = minPTPFrameSize * mr_alsa_audio_pcm_hardware_capture.channels_min * (t.min >> 3); // amount of data in bytes for min channels, smallest sample size in bytes, minimum period size
         period_bytes_max = maxPTPFrameSize * mr_alsa_audio_pcm_hardware_capture.channels_max * (t.max >> 3); // amount of data in bytes for max channels, largest sample size in bytes, maximum period size
         periods_min = 2;
-        periods_max = MR_ALSA_RINGBUFFER_NB_FRAMES / minPTPFrameSize;
+        periods_max = MR_ALSA_RINGBUFFER_NB_FRAMES / maxPTPFrameSize;
+
+        printk("mr_alsa_audio_pcm_open: capture period size range: [%zu, %zu], periods range: [%u, %u]\n",
+              period_bytes_min, period_bytes_max, periods_min, periods_max);
 
         mr_alsa_audio_pcm_hardware_capture.period_bytes_min = period_bytes_min;
         mr_alsa_audio_pcm_hardware_capture.period_bytes_max = period_bytes_max;
@@ -1769,7 +1775,7 @@ static int mr_alsa_audio_pcm_open(struct snd_pcm_substream *substream)
     ///Periods
 
     /// Update the Period Sizes Static array accordingly
-    printk(KERN_DEBUG "\nCurrent PTPFrame Size = %u\n", ptp_frame_size);
+    printk(KERN_DEBUG "Current PTPFrame Size = %u\n", ptp_frame_size);
     for(idx = 0; idx < ARRAY_SIZE(g_supported_period_sizes); ++idx)
     {
         g_supported_period_sizes[idx] = min(minPTPFrameSize << idx, maxPTPFrameSize);
@@ -1927,7 +1933,6 @@ static int mr_alsa_audio_preallocate_memory(struct mr_alsa_audio_chip *chip)
     pcm = chip->pcm;
     wanted = mr_alsa_audio_pcm_hardware_playback.buffer_bytes_max; // MR_ALSA_RINGBUFFER_NB_FRAMES * MR_ALSA_NB_CHANNELS_MAX * 4;
 
-
     chip->playback_buffer = vmalloc(wanted);
     if(!chip->playback_buffer)
     {
@@ -1935,6 +1940,7 @@ static int mr_alsa_audio_preallocate_memory(struct mr_alsa_audio_chip *chip)
         printk(KERN_ERR "mr_alsa_audio_preallocate_memory: could not allocate playback buffer (%zd bytes vmalloc requested...\n", wanted);
         goto _failed;
     }
+    printk("mr_alsa_audio_preallocate_memory: allocated playback buffer of %zd bytes vmalloc requested\n", wanted);
     memset(chip->playback_buffer, 0, wanted);
 
     wanted = mr_alsa_audio_pcm_hardware_capture.buffer_bytes_max; // MR_ALSA_RINGBUFFER_NB_FRAMES * MR_ALSA_NB_CHANNELS_MAX * 4;
@@ -1946,6 +1952,7 @@ static int mr_alsa_audio_preallocate_memory(struct mr_alsa_audio_chip *chip)
         printk(KERN_ERR "mr_alsa_audio_preallocate_memory: could not allocate capture buffer (%zd bytes vmalloc requested...\n", wanted);
         goto _failed;
     }
+    printk("mr_alsa_audio_preallocate_memory: allocated capture buffer of %zd bytes vmalloc requested\n", wanted);
     memset(chip->capture_buffer, 0, wanted);
     for (i = 0; i < MR_ALSA_NB_CHANNELS_MAX; i++)
     {

--- a/driver/audio_driver.c
+++ b/driver/audio_driver.c
@@ -1670,7 +1670,7 @@ static int mr_alsa_audio_pcm_open(struct snd_pcm_substream *substream)
         period_bytes_min = minPTPFrameSize * mr_alsa_audio_pcm_hardware_playback.channels_min * (t.min >> 3); // amount of data in bytes for min channels, smallest sample size in bytes, minimum period size
         period_bytes_max = maxPTPFrameSize * mr_alsa_audio_pcm_hardware_playback.channels_max * (t.max >> 3); // amount of data in bytes for max channels, largest sample size in bytes, maximum period size
         periods_min = 2;
-        periods_max = MR_ALSA_RINGBUFFER_NB_FRAMES / maxPTPFrameSize;
+        periods_max = MR_ALSA_RINGBUFFER_NB_FRAMES / ptp_frame_size;
 
         mr_alsa_audio_pcm_hardware_playback.period_bytes_min = period_bytes_min;
         mr_alsa_audio_pcm_hardware_playback.period_bytes_max = period_bytes_max;
@@ -1736,7 +1736,7 @@ static int mr_alsa_audio_pcm_open(struct snd_pcm_substream *substream)
         period_bytes_min = minPTPFrameSize * mr_alsa_audio_pcm_hardware_capture.channels_min * (t.min >> 3); // amount of data in bytes for min channels, smallest sample size in bytes, minimum period size
         period_bytes_max = maxPTPFrameSize * mr_alsa_audio_pcm_hardware_capture.channels_max * (t.max >> 3); // amount of data in bytes for max channels, largest sample size in bytes, maximum period size
         periods_min = 2;
-        periods_max = MR_ALSA_RINGBUFFER_NB_FRAMES / maxPTPFrameSize;
+        periods_max = MR_ALSA_RINGBUFFER_NB_FRAMES / ptp_frame_size;
 
         printk("mr_alsa_audio_pcm_open: capture period size range: [%zu, %zu], periods range: [%u, %u]\n",
               period_bytes_min, period_bytes_max, periods_min, periods_max);

--- a/driver/audio_driver.c
+++ b/driver/audio_driver.c
@@ -1775,7 +1775,6 @@ static int mr_alsa_audio_pcm_open(struct snd_pcm_substream *substream)
     ///Periods
 
     /// Update the Period Sizes Static array accordingly
-    printk(KERN_DEBUG "Current PTPFrame Size = %u\n", ptp_frame_size);
     for(idx = 0; idx < ARRAY_SIZE(g_supported_period_sizes); ++idx)
     {
         g_supported_period_sizes[idx] = min(minPTPFrameSize << idx, maxPTPFrameSize);
@@ -1790,9 +1789,9 @@ static int mr_alsa_audio_pcm_open(struct snd_pcm_substream *substream)
                         mr_alsa_audio_hw_rule_period_size_by_rate, chip,
                         SNDRV_PCM_HW_PARAM_RATE, -1);
 
+    printk("Current PTPFrame Size = %u, minPTPFrameSize = %u, maxPTPFrameSize = %u\n", 
+        ptp_frame_size, minPTPFrameSize, maxPTPFrameSize);
 
-    printk("minPTPFrameSize = %d\n", minPTPFrameSize);
-    printk("maxPTPFrameSize = %d\n", maxPTPFrameSize);
     snd_pcm_hw_constraint_step(runtime, 0, SNDRV_PCM_HW_PARAM_BUFFER_SIZE, minPTPFrameSize);
 
 #if 0

--- a/driver/manager.c
+++ b/driver/manager.c
@@ -1089,7 +1089,7 @@ void MuteInputBuffer(struct TManager* self)
     }
 
     //MTAL_DP("Input Buffer muted with 0x%x\n", get_live_in_mute_pattern(0));
-    memset(inputBuffer, get_live_in_mute_pattern(self, 0), sizeof(int32_t) * bufferLength * MAX_NUMBEROFINPUTS);
+    memset(inputBuffer, get_live_in_mute_pattern(self, 0), sizeof(int32_t) * bufferLength * self->m_NumberOfInputs);
 
     self->m_alsa_driver_frontend->unlock_capture_buffer(self->m_pALSAChip, &flags);
 }
@@ -1116,7 +1116,7 @@ void MuteOutputBuffer(struct TManager* self)
     }
 
     //MTAL_DP("Output Buffer muted with 0x%x\n", get_live_out_mute_pattern(self, 0));
-    memset(outputBuffer, get_live_out_mute_pattern(self, 0), sizeof(int32_t) * bufferLength * MAX_NUMBEROFOUTPUTS);
+    memset(outputBuffer, get_live_out_mute_pattern(self, 0), sizeof(int32_t) * bufferLength * self->m_NumberOfOutputs);
 
     self->m_alsa_driver_frontend->unlock_playback_buffer(self->m_pALSAChip, &flags);
 }

--- a/driver/module_interface.c
+++ b/driver/module_interface.c
@@ -59,7 +59,7 @@
 MODULE_LICENSE("GPL v2");
 MODULE_AUTHOR("Merging Technologies <alsa@merging.com>");
 MODULE_DESCRIPTION("Merging Technologies RAVENNA ALSA driver"); // see modinfo
-MODULE_VERSION("bondagit-1.6");
+MODULE_VERSION("bondagit-1.7");
 //MODULE_SUPPORTED_DEVICE("{{ALSA,Merging RAVENNA}}");
 
 


### PR DESCRIPTION
Added support for sample rates 192Khz and 384Khz.
Fixed compilation with Linux Kernel v6.2 and above.
Changed driver version to bondagit-1.7.