### PR TITLE
c_wrapper_lib: fix skb pointers prior to xmit

### DIFF
--- a/driver/c_wrapper_lib.c
+++ b/driver/c_wrapper_lib.c
@@ -151,7 +151,8 @@ int CW_socket_tx_packet(void* skb, unsigned int data_len, const char* iface)
             irqCheckOnce = 1;
         }
     }
-    skb_reset_network_header(skb_ptr);
+    skb_reset_mac_header(skb_ptr);
+    skb_set_network_header(skb_ptr, ETH_HLEN);
 
 //#define NO_TX
 #ifdef NO_TX


### PR DESCRIPTION
The current code resets the network header pointer to the beginning of the skb, which is wrong. The skb's linear section starts with the MAC header, followed by the IP header.

This is not an issue as long as the kernel's IP stack passes the skb unmodified to the network interface for egress. If the flow in intercepted by an nft hook, however, the correctness of the header pointers matters.
